### PR TITLE
Fix key note url link

### DIFF
--- a/index.html
+++ b/index.html
@@ -209,7 +209,7 @@
         Promise.all(
           data.map(d => {
             const keynote = {
-              url: d.url,
+              url: d.html_url,
               user: d.user,
               body: d.body,
               title: d.body.split('\r\n')[0].replace(/\*\*/g, '')


### PR DESCRIPTION
Fixing Keynote url Bug.
Previous using **_url_** from api, now using **_html_url_**.